### PR TITLE
Set LANG=C in makelinks to keep sort stable

### DIFF
--- a/makelinks
+++ b/makelinks
@@ -33,4 +33,4 @@ GNUFIND=find
 # https://formulae.brew.sh/formula/findutils
 which gfind >/dev/null && GNUFIND=gfind
 
-"${GNUFIND}" links -type l -printf '%f\t%l\n' | sort | tee links/map.txt
+"${GNUFIND}" links -type l -printf '%f\t%l\n' | LANG=C sort | tee links/map.txt


### PR DESCRIPTION
Running makelinks with eg. LANG=en_AU.UTF-8 will change the sort order of
map.txt, leading to a large and ugly diff.

Set LANG=C when running sort to ensure the sort order is stable regardless of a
particular user's LANG.